### PR TITLE
fix: handle grouped renovate prs

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -36,7 +36,7 @@ jobs:
       - run: yarn test --coverage
       - uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
       - name: Update eslint-ci-rules if needed
-        if: contains(github.event.head_commit.message, 'update dependency eslint-config-txo')
+        if: ${{ contains(github.event.head_commit.message, 'update dependency eslint-config-txo') || contains(github.event.head_commit.message, 'update eslint txo packages') }}
         run: |
           if ! yarn lint:ci; then
             echo "Linting failed. Updating eslint-ci-rules.json..."


### PR DESCRIPTION
This handles PRs that are grouped using a group we defined in the config
https://github.com/technology-studio/renovate-config/blob/main/default.json#L48-L58