### PR TITLE
fix: compute cache keys in dedicated step to ensure they are always available

### DIFF
--- a/.github/actions/install-dependencies-bun/action.yml
+++ b/.github/actions/install-dependencies-bun/action.yml
@@ -12,10 +12,10 @@ outputs:
     value: ${{ steps.bun-cache-dir.outputs.dir }}
   download-cache-primary-key:
     description: The cache key used for restoring the bun cache
-    value: ${{ steps.cache-restore-bun.outputs.cache-primary-key }}
+    value: ${{ steps.cache-keys.outputs.download-cache-primary-key }}
   node-modules-primary-key:
     description: The cache key used for restoring the node modules
-    value: ${{ steps.cache-restore-node-modules.outputs.cache-primary-key }}
+    value: ${{ steps.cache-keys.outputs.node-modules-primary-key }}
 runs:
   using: 'composite'
   steps:
@@ -25,12 +25,17 @@ runs:
     - run: echo "dir=$(bun pm cache)" >> $GITHUB_OUTPUT
       shell: bash
       id: bun-cache-dir
+    - run: |
+        echo "download-cache-primary-key=${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}" >> $GITHUB_OUTPUT
+        echo "node-modules-primary-key=${{ runner.os }}-node_modules-${{ hashFiles('bun.lock') }}" >> $GITHUB_OUTPUT
+      shell: bash
+      id: cache-keys
     - uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
       if: inputs.use-cache == 'true'
       id: cache-restore-bun
       with:
         path: ${{ steps.bun-cache-dir.outputs.dir }}
-        key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+        key: ${{ steps.cache-keys.outputs.download-cache-primary-key }}
         restore-keys: |
           ${{ runner.os }}-bun-
     - uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
@@ -38,7 +43,7 @@ runs:
       id: cache-restore-node-modules
       with:
         path: node_modules
-        key: ${{ runner.os }}-node_modules-${{ hashFiles('bun.lock') }}
+        key: ${{ steps.cache-keys.outputs.node-modules-primary-key }}
         restore-keys: |
           ${{ runner.os }}-node_modules-
     - run: bun install --frozen-lockfile

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -12,10 +12,10 @@ outputs:
     value: ${{ steps.yarn-cache-dir.outputs.dir }}
   download-cache-primary-key:
     description: The cache key used for restoring the yarn cache
-    value: ${{ steps.cache-restore-yarn.outputs.cache-primary-key }}
+    value: ${{ steps.cache-keys.outputs.download-cache-primary-key }}
   node-modules-primary-key:
     description: The cache key used for restoring the node modules
-    value: ${{ steps.cache-restore-node-modules.outputs.cache-primary-key }}
+    value: ${{ steps.cache-keys.outputs.node-modules-primary-key }}
 runs:
   using: 'composite'
   steps:
@@ -25,12 +25,17 @@ runs:
     - run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
       shell: bash
       id: yarn-cache-dir
+    - run: |
+        echo "download-cache-primary-key=${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}" >> $GITHUB_OUTPUT
+        echo "node-modules-primary-key=${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}" >> $GITHUB_OUTPUT
+      shell: bash
+      id: cache-keys
     - uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
       if: inputs.use-cache == 'true'
       id: cache-restore-yarn
       with:
         path: ${{ steps.yarn-cache-dir.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+        key: ${{ steps.cache-keys.outputs.download-cache-primary-key }}
         restore-keys: |
           ${{ runner.os }}-yarn-
     - uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
@@ -38,7 +43,7 @@ runs:
       id: cache-restore-node-modules
       with:
         path: node_modules
-        key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock') }}
+        key: ${{ steps.cache-keys.outputs.node-modules-primary-key }}
         restore-keys: |
           ${{ runner.os }}-node_modules-
     - run: yarn install --frozen-lockfile


### PR DESCRIPTION
Cache key outputs previously referenced `actions/cache/restore` step outputs, which are empty when `use-cache` is false (steps are skipped). Compute keys in an unconditional step so save-dependencies always receives valid cache keys.