### PR TITLE
feat: add release workflow for bun

### DIFF
--- a/.github/workflows/_release-bun.yml
+++ b/.github/workflows/_release-bun.yml
@@ -1,0 +1,84 @@
+name: Release (bun)
+
+on:
+  workflow_call:
+    inputs:
+      cache_mode:
+        type: string
+        default: download
+    secrets:
+      SEMANTIC_RELEASE_SLACK_WEBHOOK:
+        required: true
+      TXO_GITHUB_BOT_APP_ID:
+        required: true
+      TXO_GITHUB_BOT_APP_PRIVATE_KEY:
+        required: true
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  release:
+    name: "/"
+    runs-on: ubuntu-latest
+    environment: default-branch-semantic-release
+    steps:
+      - uses: technology-studio/github-workflows/.github/actions/github-app-token-generator@main
+        id: get-token
+        with:
+          app-id: ${{ secrets.TXO_GITHUB_BOT_APP_ID }}
+          private-key: ${{ secrets.TXO_GITHUB_BOT_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: technology-studio/github-workflows/.github/actions/install-dependencies-bun@main
+        id: install
+        with:
+          use-cache: false
+      - run: bun run test --coverage
+      - name: Check if coverage was generated
+        id: check-coverage
+        run: |
+          if [[ -d "coverage" ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+      - if: steps.check-coverage.outputs.exists == 'true'
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
+      - name: Update eslint-ci-rules if needed
+        if: ${{ contains(github.event.head_commit.message, 'update dependency eslint-config-txo') || contains(github.event.head_commit.message, 'update eslint txo packages') }}
+        run: |
+          if ! bun run --bun lint:ci; then
+            echo "Linting failed. Updating eslint-ci-rules.json..."
+            bun run --bun txo-eslint update-ci-rules
+            changed_files=$(git diff --name-only)
+            if [[ "$changed_files" == "eslint-ci-rules.json" ]]; then
+              git config --global user.email "txo-github-bot[bot]@users.noreply.github.com"
+              git config --global user.name "TXO GitHub Bot[bot]"
+              git remote set-url origin https://x-access-token:${{ steps.get-token.outputs.token }}@github.com/${{ github.repository }}
+              git add eslint-ci-rules.json
+              git commit -m "chore: update eslint-ci-rules.json [skip ci]"
+              git push
+            fi
+          else
+            echo "Linting passed. No update needed."
+          fi
+      - run: bun run semantic-release
+        env:
+          GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
+          SLACK_WEBHOOK: ${{ secrets.SEMANTIC_RELEASE_SLACK_WEBHOOK }}
+      - uses: technology-studio/github-workflows/.github/actions/save-dependencies@main
+        with:
+          cache_mode: ${{ inputs.cache_mode }}
+          download-cache-dir: ${{ steps.install.outputs.download-cache-dir }}
+          download-cache-primary-key: ${{ steps.install.outputs.download-cache-primary-key }}
+          node-modules-primary-key: ${{ steps.install.outputs.node-modules-primary-key }}
+      - name: Send a Slack message on failure
+        if: failure()
+        uses: technology-studio/github-workflows/.github/actions/slack-failed-job-message@main
+        with:
+          slack_bot_token: ${{ secrets.TXO_SLACK_BOT_APP_TOKEN }}
+          channel_id: ${{ secrets.TXO_SLACK_GITHUB_OPS_CHANNEL_ID }}

--- a/.github/workflows/_release-bun.yml
+++ b/.github/workflows/_release-bun.yml
@@ -1,4 +1,4 @@
-name: Release (bun)
+name: Release
 
 on:
   workflow_call:


### PR DESCRIPTION
Closes TSD-22.

Adds `.github/workflows/_release-bun.yml` — the bun counterpart of `_release.yml`.

It's the public `_release.yml` with bun swapped in, so it keeps all the public-specific setup: OIDC trusted publishing (`permissions: id-token: write`, `environment: default-branch-semantic-release`, no npm secrets), `checkout` v6 and codecov `671740a`.

## Bun-specific changes

- `install-dependencies-bun@main` instead of `install-dependencies@main`
- `bun run test --coverage`, `bun run --bun lint:ci`, `bun run --bun txo-eslint update-ci-rules`, `bun run semantic-release`
- coverage-directory guard before the codecov upload

## Fixes vs. the private `_release-bun.yml`

1. **`use-cache: false` on install** — the private variant omits it, so it restores cache during a release, unlike both yarn release workflows.
2. **Coverage guard uses `$GITHUB_OUTPUT`** — the private variant still uses the disabled `::set-output` syntax, so its codecov upload is effectively always skipped.

## Note

semantic-release's OIDC publishing needs npm >= 11.5.1 on the runner. `bun run semantic-release` still shells out to the runner's npm for the publish itself, so this should behave like the yarn workflow — but the yarn path is the only one proven in CI so far.

🤖 Generated with [Claude Code](https://claude.com/claude-code)