### PR TITLE
fix: replace custom app token generation with actions/create-github-app-token

### DIFF
--- a/.github/actions/github-app-token-generator/action.yml
+++ b/.github/actions/github-app-token-generator/action.yml
@@ -1,64 +1,42 @@
 name: Generate GitHub App token
-description: Generate a GitHub App token
+description: Generate a GitHub App installation access token
 author: 'Technology Studio'
 inputs:
   app-id:
-    description: The GitHub App ID
-    required: true
+    description: The GitHub App ID. Deprecated upstream, prefer client-id.
+    required: false
+  client-id:
+    description: The GitHub App Client ID
+    required: false
   private-key:
     description: The GitHub App private key
     required: true
+  owner:
+    description: >-
+      Owner of the installation. Defaults to the current repository owner, which scopes the
+      token to every repository in that owner's installation. Narrow it with `repositories`.
+    required: false
+  repositories:
+    description: Comma or newline separated repositories to scope the token to. Defaults to the current repository.
+    required: false
 outputs:
   token:
     description: The GitHub App token
     value: ${{ steps.generate_token.outputs.token }}
+  installation-id:
+    description: The GitHub App installation ID
+    value: ${{ steps.generate_token.outputs.installation-id }}
+  app-slug:
+    description: The GitHub App slug
+    value: ${{ steps.generate_token.outputs.app-slug }}
 runs:
   using: 'composite'
   steps:
-    - name: Generate JWT Header and Payload
-      id: generate_header_payload
-      shell: bash
-      run: |
-        HEADER=$(echo -n '{"alg":"RS256","typ":"JWT"}' | openssl base64 | tr -d '=' | tr '/+' '_-' | tr -d '\n')
-        PAYLOAD=$(echo -n '{"iat":'$(date +%s)',"exp":'$(($(date +%s)+600))',"iss":"${{ inputs.app-id }}"}' | openssl base64 | tr -d '=' | tr '/+' '_-' | tr -d '\n')
-        # Combine header and payload
-        HEADER_PAYLOAD="${HEADER}.${PAYLOAD}"
-        echo "HEADER_PAYLOAD=$HEADER_PAYLOAD" >> $GITHUB_ENV
-    - name: Sign JWT with private key
-      id: sign_jwt
-      shell: bash
-      env:
-        PRIVATE_KEY: ${{ inputs.private-key }}
-      run: |
-        echo "${PRIVATE_KEY}" > private-key.pem
-        SIGNATURE=$(echo -n "${HEADER_PAYLOAD}" | openssl dgst -sha256 -sign private-key.pem | openssl base64 | tr -d '=' | tr '/+' '_-' | tr -d '\n')
-        rm private-key.pem
-
-        JWT="${HEADER_PAYLOAD}.${SIGNATURE}"
-        echo "jwt=$JWT" >> $GITHUB_ENV
-    - name: Generate token
+    - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       id: generate_token
-      shell: bash
-      env:
-        repo: ${{ github.repository }}
-      run: |
-        response=$(curl -s -H "Authorization: Bearer ${jwt}" -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/${repo}/installation")
-        installation_id=$(echo "$response" | jq -r .id)
-
-        if [ "$installation_id" = "null" ]; then
-            echo "Unable to get installation ID. Is the GitHub App installed on ${repo}?"
-            echo "$response" | jq -r .message
-            exit 1
-        fi
-
-        token=$(curl -s -X POST \
-                     -H "Authorization: Bearer ${jwt}" \
-                     -H "Accept: application/vnd.github.v3+json" \
-                     https://api.github.com/app/installations/"${installation_id}"/access_tokens | jq -r .token)
-
-        if [ "$token" = "null" ]; then
-            echo "Unable to generate installation access token"
-            exit 1
-        fi
-
-        echo "token=${token}" >> "$GITHUB_OUTPUT"
+      with:
+        app-id: ${{ inputs.app-id }}
+        client-id: ${{ inputs.client-id }}
+        private-key: ${{ inputs.private-key }}
+        owner: ${{ inputs.owner || github.repository_owner }}
+        repositories: ${{ inputs.repositories }}

--- a/.github/actions/github-app-token-generator/action.yml
+++ b/.github/actions/github-app-token-generator/action.yml
@@ -13,8 +13,9 @@ inputs:
     required: true
   owner:
     description: >-
-      Owner of the installation. Defaults to the current repository owner, which scopes the
-      token to every repository in that owner's installation. Narrow it with `repositories`.
+      Owner of the installation. When unset (the default), the token is scoped to the current
+      repository only. Setting `owner` without `repositories` scopes the token to every
+      repository in that owner's installation.
     required: false
   repositories:
     description: Comma or newline separated repositories to scope the token to. Defaults to the current repository.
@@ -38,5 +39,5 @@ runs:
         app-id: ${{ inputs.app-id }}
         client-id: ${{ inputs.client-id }}
         private-key: ${{ inputs.private-key }}
-        owner: ${{ inputs.owner || github.repository_owner }}
+        owner: ${{ inputs.owner }}
         repositories: ${{ inputs.repositories }}


### PR DESCRIPTION
Replaces the hand-rolled GitHub App token generation with the official actions/create-github-app-token action.