### PR TITLE
fix: render PR details for pull_request_target events

### DIFF
--- a/.github/actions/slack-failed-job-message/action.yml
+++ b/.github/actions/slack-failed-job-message/action.yml
@@ -35,7 +35,7 @@ runs:
           echo "\`${REPOSITORY}\` Workflow <${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}|${WORKFLOW}> failed"
 
           case "${EVENT_NAME}" in
-            pull_request)
+            pull_request | pull_request_target)
               echo "PR <${PR_URL}|${PR_TITLE} #${PR_NUMBER}>"
               ;;
             schedule)


### PR DESCRIPTION
Matches pull_request_target in the event case so the message includes the PR link.