### PR TITLE
fix: build the Slack payload as JSON

### DIFF
--- a/.github/actions/slack-failed-job-message/action.yml
+++ b/.github/actions/slack-failed-job-message/action.yml
@@ -63,5 +63,4 @@ runs:
         method: chat.postMessage
         token: ${{ inputs.slack_bot_token }}
         payload: |
-          channel: ${{ inputs.channel_id }}
-          text: "${{ env.SLACK_MESSAGE }}"
+          {"channel": ${{ toJSON(inputs.channel_id) }}, "text": ${{ toJSON(env.SLACK_MESSAGE) }}}


### PR DESCRIPTION
Builds the chat.postMessage payload as JSON.