### PR TITLE
chore: declare slack secrets in semantic title workflow

### DIFF
--- a/.github/workflows/_semantic-title.yml
+++ b/.github/workflows/_semantic-title.yml
@@ -2,6 +2,11 @@ name: "PR"
 
 on:
   workflow_call:
+    secrets:
+      TXO_SLACK_BOT_APP_TOKEN:
+        required: true
+      TXO_SLACK_GITHUB_OPS_CHANNEL_ID:
+        required: true
 
 permissions:
   pull-requests: read


### PR DESCRIPTION
Declares the two Slack secrets in the workflow_call interface of _semantic-title.yml.