### PR TITLE
feat: report codecov failures to slack without failing the job

### DIFF
--- a/.github/workflows/_release-bun.yml
+++ b/.github/workflows/_release-bun.yml
@@ -42,7 +42,18 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
       - if: steps.check-coverage.outputs.exists == 'true'
+        id: codecov
+        continue-on-error: true
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        with:
+          fail_ci_if_error: true
+      - name: Send a Slack message on codecov failure
+        if: steps.codecov.outcome == 'failure'
+        uses: technology-studio/github-workflows/.github/actions/slack-failed-job-message@main
+        with:
+          slack_bot_token: ${{ secrets.TXO_SLACK_BOT_APP_TOKEN }}
+          channel_id: ${{ secrets.TXO_SLACK_GITHUB_OPS_CHANNEL_ID }}
+          status_text: '🟠 codecov upload failed (job continued)'
       - run: bun run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -33,7 +33,18 @@ jobs:
         with:
           use-cache: false
       - run: yarn test --coverage
-      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+      - id: codecov
+        continue-on-error: true
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        with:
+          fail_ci_if_error: true
+      - name: Send a Slack message on codecov failure
+        if: steps.codecov.outcome == 'failure'
+        uses: technology-studio/github-workflows/.github/actions/slack-failed-job-message@main
+        with:
+          slack_bot_token: ${{ secrets.TXO_SLACK_BOT_APP_TOKEN }}
+          channel_id: ${{ secrets.TXO_SLACK_GITHUB_OPS_CHANNEL_ID }}
+          status_text: '🟠 codecov upload failed (job continued)'
       - run: yarn semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -19,7 +19,18 @@ jobs:
             echo "::set-output name=exists::false"
           fi
       - if: steps.check-dir.outputs.exists == 'true'
+        id: codecov
+        continue-on-error: true
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+        with:
+          fail_ci_if_error: true
+      - name: Send a Slack message on codecov failure
+        if: steps.codecov.outcome == 'failure'
+        uses: technology-studio/github-workflows/.github/actions/slack-failed-job-message@main
+        with:
+          slack_bot_token: ${{ secrets.TXO_SLACK_BOT_APP_TOKEN }}
+          channel_id: ${{ secrets.TXO_SLACK_GITHUB_OPS_CHANNEL_ID }}
+          status_text: '🟠 codecov upload failed (job continued)'
       - name: Send a Slack message on failure
         if: failure()
         uses: technology-studio/github-workflows/.github/actions/slack-failed-job-message@main


### PR DESCRIPTION
Codecov step failures now post a Slack message; the job continues.