### PR TITLE
fix: use oidc for codecov upload in release workflows

### DIFF
--- a/.github/workflows/_release-bun.yml
+++ b/.github/workflows/_release-bun.yml
@@ -47,6 +47,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           fail_ci_if_error: true
+          use_oidc: true
       - name: Send a Slack message on codecov failure
         if: steps.codecov.outcome == 'failure'
         uses: technology-studio/github-workflows/.github/actions/slack-failed-job-message@main

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -38,6 +38,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           fail_ci_if_error: true
+          use_oidc: true
       - name: Send a Slack message on codecov failure
         if: steps.codecov.outcome == 'failure'
         uses: technology-studio/github-workflows/.github/actions/slack-failed-job-message@main


### PR DESCRIPTION
Enables OIDC for the codecov steps in the release workflows.