### PR TITLE
fix: use oidc for codecov upload in unit test workflow

### DIFF
--- a/.github/workflows/_unit-test.yml
+++ b/.github/workflows/_unit-test.yml
@@ -7,6 +7,9 @@ jobs:
   unit-test:
     name: "/"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: technology-studio/github-workflows/.github/actions/install-dependencies@main
@@ -24,6 +27,7 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           fail_ci_if_error: true
+          use_oidc: true
       - name: Send a Slack message on codecov failure
         if: steps.codecov.outcome == 'failure'
         uses: technology-studio/github-workflows/.github/actions/slack-failed-job-message@main


### PR DESCRIPTION
Enables OIDC for the codecov step in the unit test workflow and scopes job permissions.